### PR TITLE
fix: do not fail out init if drag and drop fails

### DIFF
--- a/src/app/core.ts
+++ b/src/app/core.ts
@@ -22,10 +22,11 @@ export const testConnection = (): Promise<any> => {
 
 /**
  * Initialize drag and drop.
+ * @param initCall - Indicate if called via init flow and should not reject
  *
  * @returns a promise that resolves if the initialization was successful or not
  */
-export const initDragDrop = (): Promise<boolean> => {
+export const initDragDrop = (initCall?: boolean): Promise<boolean> => {
   if (!asperaSdk.isReady) {
     return throwError(messages.serverNotVerified);
   }
@@ -36,7 +37,13 @@ export const initDragDrop = (): Promise<boolean> => {
     .then((data: boolean) => promiseInfo.resolver(data))
     .catch(error => {
       errorLog(messages.dragDropInitFailed, error);
-      promiseInfo.rejecter(generateErrorBody(messages.dragDropInitFailed, error));
+
+      if (initCall) {
+        promiseInfo.resolver(false);
+        errorLog(messages.dragDropInitFailedInit, error);
+      } else {
+        promiseInfo.rejecter(generateErrorBody(messages.dragDropInitFailed, error));
+      }
     });
 
   return promiseInfo.promise;
@@ -73,7 +80,7 @@ export const init = (options?: InitOptions): Promise<any> => {
 
   return asperaSdk.activityTracking.setup()
     .then(() => testConnection())
-    .then(() => initDragDrop())
+    .then(() => initDragDrop(true))
     .catch(error => {
       errorLog(messages.serverError, error);
       asperaSdk.globals.asperaAppVerified = false;

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -2,6 +2,7 @@
 export const messages = {
   callbackIsNotFunction: 'The provided callback is not a function',
   dragDropInitFailed: 'Unable to initialize drag-drop',
+  dragDropInitFailedInit: 'Unable to initialize drag-drop as part of init flow',
   failedToGenerateIframe: 'Unable to generate IFRAME for download. Using new window',
   getInstallerError: 'Unable to get latest installers',
   getAllTransfersFailed: 'Unable to get all transfers',


### PR DESCRIPTION
I think if drag and drop fails we don't need to kill the init flow. But if called otherwise error it.