### PR TITLE
fix: set signed url protocol based on gateway url scheme

### DIFF
--- a/src/http-gateway/download.ts
+++ b/src/http-gateway/download.ts
@@ -45,7 +45,7 @@ const httpDownloadPresigned = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
     headers['X-Aspera-AccessKey'] = asperaSdkSpec.http_gateway_authentication.access_key;
   }
 
-  const protocol = window.location.protocol === 'https:' ? 'https' : 'http';
+  const protocol = url.protocol === 'https:' ? 'https' : 'http';
 
   return fetch(
     `${url.toString()}/presign`,


### PR DESCRIPTION
If the HTTP Gateway is listening over HTTPS then we want to generate a signed URL using the `https` protocol.