### PR TITLE
feat: get capabilities

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -34,4 +34,5 @@ export const messages = {
   httpNetworkFail: 'HTTP network encountered unknown error.',
   readAsArrayBufferFailed: 'Unable to read file as array buffer',
   readChunkAsArrayBufferFailed: 'Unable to read file chunk as array buffer',
+  rpcDiscoverFailed: 'Unable to discover RPC endpoints',
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import {AsperaSdk} from './models/aspera-sdk.model';
-import {createDropzone, deregisterActivityCallback, deregisterStatusCallback, getAllTransfers, getInfo, getTransfer, init, initDragDrop, modifyTransfer, readAsArrayBuffer, readChunkAsArrayBuffer, registerActivityCallback, registerStatusCallback, removeDropzone, removeTransfer, resumeTransfer, setBranding, showDirectory, showPreferences, showSelectFileDialog, showSelectFolderDialog, startTransfer, stopTransfer, testConnection,} from './app/core';
+import {createDropzone, deregisterActivityCallback, deregisterStatusCallback, getAllTransfers, getCapabilities, getInfo, getTransfer, init, initDragDrop, modifyTransfer, readAsArrayBuffer, readChunkAsArrayBuffer, registerActivityCallback, registerStatusCallback, removeDropzone, removeTransfer, resumeTransfer, setBranding, showDirectory, showPreferences, showSelectFileDialog, showSelectFolderDialog, startTransfer, stopTransfer, testConnection,} from './app/core';
 import {getInstallerInfo} from './app/installer';
 import {getInstallerUrls, isSafari} from './helpers/helpers';
 import * as httpGatewayCalls from './http-gateway';
@@ -33,6 +33,7 @@ asperaSdk.readAsArrayBuffer = readAsArrayBuffer;
 asperaSdk.readChunkAsArrayBuffer = readChunkAsArrayBuffer;
 asperaSdk.isSafari = isSafari;
 asperaSdk.getInstallerUrls = getInstallerUrls;
+asperaSdk.getCapabilities = getCapabilities;
 asperaSdk.httpGatewayCalls = httpGatewayCalls;
 
 const launch = asperaSdk.globals.launch;
@@ -71,13 +72,7 @@ export {
   readAsArrayBuffer,
   readChunkAsArrayBuffer,
   getInstallerUrls,
+  getCapabilities,
 };
 
 export default asperaSdk;
-
-export type {
-  ReadAsArrayBufferRequest,
-  ReadAsArrayBufferResponse,
-  ReadChunkAsArrayBufferRequest,
-  ReadChunkAsArrayBufferResponse,
-} from './models/models';

--- a/src/models/aspera-sdk.model.ts
+++ b/src/models/aspera-sdk.model.ts
@@ -1,4 +1,4 @@
-import {CustomBrandingOptions, DataTransferResponse, AsperaSdkSpec, AsperaSdkTransfer, FileDialogOptions, FolderDialogOptions, InitOptions, InstallerInfoResponse, InstallerOptions, ModifyTransferOptions, ResumeTransferOptions, SafariExtensionEvent, TransferSpec, WebsocketEvent, InstallerUrlInfo} from './models';
+import {CustomBrandingOptions, DataTransferResponse, AsperaSdkSpec, AsperaSdkTransfer, FileDialogOptions, FolderDialogOptions, InitOptions, InstallerInfoResponse, InstallerOptions, ModifyTransferOptions, ResumeTransferOptions, SafariExtensionEvent, TransferSpec, WebsocketEvent, InstallerUrlInfo, RpcMethod, SdkCapabilities} from './models';
 import {hiddenStyleList, installerUrl, protocol} from '../constants/constants';
 import {messages} from '../constants/messages';
 import {safariClient} from '../helpers/client/safari-client';
@@ -15,6 +15,8 @@ class AsperaSdkGlobals {
   asperaAppUrl = 'http://127.0.0.1';
   /** The URL of the IBM Aspera Desktop HTTP server to use with the SDK */
   rpcPort = 33024;
+  /** The list of RPC methods supported by the running IBM Aspera for desktop application */
+  rpcMethods: string[] = [];
   /** The default URL to check for latest Aspera installers */
   installerUrl = installerUrl;
   /** Aspera SDK info */
@@ -406,6 +408,8 @@ export class AsperaSdk {
   isSafari: () => boolean;
   /** Function to get URLs for installer management. */
   getInstallerUrls: () => InstallerUrlInfo;
+  /** Function to get the SDK capabilities. */
+  getCapabilities: () => SdkCapabilities;
   /** Indicate if Safari Extension is enabled. If the extension is disabled during the lifecycle this will not update to disabled. */
   SAFARI_EXTENSION_STATUS: SafariExtensionEvent = 'DISABLED';
   /** Aspera HTTP Gateway calls. This normally is not needed by clients but expose just in case. */

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -770,3 +770,26 @@ export interface InstallerUrlInfo {
   /** URL to the latest installers (GA release) */
   latest: string;
 }
+
+export interface OpenRpcSpec {
+  /** List of RPC methods supported by the application */
+  methods: RpcMethod[]
+}
+
+export interface RpcMethod {
+  /** The RPC method name */
+  name: string;
+}
+
+/**
+ * Describes the high-level capabilities supported by the SDK.
+ */
+export interface SdkCapabilities {
+  /**
+   * Whether the SDK can read file contents for generating image previews.
+   *
+   * Image preview is supported if the SDK is using HTTP Gateway, Connect, or IBM Aspera for desktop
+   * with the required RPC methods.
+  */
+  imagePreview: boolean,
+}


### PR DESCRIPTION
Exposes a way for downstream applications to see a list of supported capabilities by their end user's transfer client.

For example, image preview is only supported starting with certain versions of IBM Aspera for desktop. Connect has supported image preview for many years, while HTTP Gateway uses a native JS implementation directly in the SDK.

Rather than a downstream app needing to either (1) handle attempting to generate an image preview and failing or (2) do manual bookkeeping to check the user's version of IBM Aspera for desktop and skipping the call, the `getCapabilities()` function can now be used to determine if image preview is supported.

In summary, a downstream app can now much more easily skip generating image previews for user selected files rather than attempting to generate one and failing.

For the desktop app, under the hood this uses the `rpc.discover` RPC method which will return the OpenRPC spec.