### PR TITLE
fix: prefer file.webkitRelativePath as map key

### DIFF
--- a/src/http-gateway/core.ts
+++ b/src/http-gateway/core.ts
@@ -170,7 +170,7 @@ export const httpGatewaySelectFileFolderDialog = (options?: FileDialogOptions, f
     for (let i = 0; i < element.files.length; i++) {
       const file = element.files[i];
       returnFiles.push(file);
-      asperaSdk.httpGatewaySelectedFiles.set(file.name, file);
+      asperaSdk.httpGatewaySelectedFiles.set(file.webkitRelativePath || file.name, file);
     }
 
     resolver({


### PR DESCRIPTION
#148 

We stored files using the `File` object's `name` field. However, the response to clients used the `webkitRelativePath` field. This forced the client to do extra-processing to get the correct `source` path in the upload transfer spec.

### Testing
Various upload scenarios via test app. 

Example:
1. User initiates upload.
2. Web app calls `showSelectFolderDialog`.
3. User chooses folder `test` that contains single file `test.txt`.
4. `showSelectFolderDialog` resolves with `test/test.txt` as the upload path.
5. Web app constructs transfer spec with `test/test.txt` as the `source` path.
6. Web app initiates transfer via `startTransfer()`.

=> Upload is successful and on destination `test/test.txt` exists.