### PR TITLE
fix: make asperaSdkSpec optional

### DIFF
--- a/src/app/core.ts
+++ b/src/app/core.ts
@@ -203,7 +203,7 @@ export const init = (options?: InitOptions): Promise<any> => {
  *
  * @returns a promise that resolves if transfer initiation is successful and rejects if transfer cannot be started
  */
-export const startTransfer = (transferSpec: TransferSpec, asperaSdkSpec: AsperaSdkSpec): Promise<AsperaSdkTransfer> => {
+export const startTransfer = (transferSpec: TransferSpec, asperaSdkSpec?: AsperaSdkSpec): Promise<AsperaSdkTransfer> => {
   if (!isValidTransferSpec(transferSpec)) {
     return throwError(messages.notValidTransferSpec, {transferSpec});
   }
@@ -222,7 +222,7 @@ export const startTransfer = (transferSpec: TransferSpec, asperaSdkSpec: AsperaS
 
   const payload = {
     transfer_spec: transferSpec,
-    desktop_spec: asperaSdkSpec,
+    desktop_spec: asperaSdkSpec || {},
     app_id: asperaSdk.globals.appId,
   };
 


### PR DESCRIPTION
#192 

In the transfer client, `desktop_spec` is a required parameter in the RPC call, which can probably be optional as well. This bubbled up to the API of `startTransfer`. However, since all fields in desktop spec are optional, we now make the argument itself optional so that consumers of the SDK do no have to add an empty object to satisfy the compiler.

## Testing
Connect and IBM Aspera for desktop as transfer clients, started transfers without specifying aspera sdk spec argument.