### PR TITLE
fix: new v3 api prefix

### DIFF
--- a/src/http-gateway/core.ts
+++ b/src/http-gateway/core.ts
@@ -44,6 +44,9 @@ export const initHttpGateway = (response: HttpGatewayInfo): Promise<void> => {
   asperaSdk.globals.httpGatewayInfo = response;
   asperaSdk.globals.httpGatewayVerified = true;
 
+  const majorVersion = Number(response.version.split('.')[0] || 3);
+  asperaSdk.globals.httpGatewayRoutePrefix = majorVersion >= 3 ? '/v3' : '';
+
   if (asperaSdk.useOldHttpGateway) {
     // Watch for old HTTP Gateway transfers in case used.
     oldHttpRegisterActivityCallback(oldHttpTransfers => {

--- a/src/http-gateway/download.ts
+++ b/src/http-gateway/download.ts
@@ -34,6 +34,7 @@ const httpDownloadPresigned = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
   };
 
   const url = new URL(asperaSdkSpec?.http_gateway_override_server_url || asperaSdk.globals.httpGatewayUrl);
+  const baseUrl = (url.origin + url.pathname).replace(/\/+$/, '');
 
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
@@ -48,7 +49,7 @@ const httpDownloadPresigned = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
   const protocol = url.protocol === 'https:' ? 'https' : 'http';
 
   return fetch(
-    `${url.toString()}/presign`,
+    `${baseUrl}${asperaSdk.globals.httpGatewayRoutePrefix}/presign`,
     {
       method: 'POST',
       headers,
@@ -131,7 +132,7 @@ const httpDownloadInBrowser = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
     headers['X-Aspera-AccessKey'] = asperaSdkSpec.http_gateway_authentication.access_key;
   }
 
-  fetch(`${asperaSdkSpec?.http_gateway_override_server_url || asperaSdk.globals.httpGatewayUrl}/download`, {method: 'GET', headers}).then(data => {
+  fetch(`${asperaSdkSpec?.http_gateway_override_server_url || asperaSdk.globals.httpGatewayUrl}${asperaSdk.globals.httpGatewayRoutePrefix}/download`, {method: 'GET', headers}).then(data => {
     const responseHeaders = data.headers;
     transferObject.httpRequestId = responseHeaders.get('X-Request-Id');
     const chunks: Uint8Array<ArrayBuffer>[] = [];

--- a/src/http-gateway/upload.ts
+++ b/src/http-gateway/upload.ts
@@ -54,7 +54,7 @@ export const httpUpload = (transferSpec: TransferSpec, asperaSdkSpec?: AsperaSdk
     request.setRequestHeader('X-Aspera-AccessKey', asperaSdkSpec.http_gateway_authentication.access_key);
   }
 
-  request.open('POST', `${asperaSdkSpec?.http_gateway_override_server_url || asperaSdk.globals.httpGatewayUrl}/upload`, true);
+  request.open('POST', `${asperaSdkSpec?.http_gateway_override_server_url || asperaSdk.globals.httpGatewayUrl}${asperaSdk.globals.httpGatewayRoutePrefix}/upload`, true);
 
   const triggerUpdate = (): void => {
     sendTransferUpdate(transferObject);

--- a/src/models/aspera-sdk.model.ts
+++ b/src/models/aspera-sdk.model.ts
@@ -33,6 +33,8 @@ export class AsperaSdkGlobals {
   dropZonesCreated: Map<string, {event: string; callback: (event: any) => void}[]> = new Map();
   /** HTTP Gateway URL after successful passing */
   httpGatewayUrl?: string;
+  /** Version-based route prefix for HTTP Gateway API endpoints (e.g. "/v3" for v3+, "" for v2) */
+  httpGatewayRoutePrefix = '';
   /** Indicate that the HTTP Gateway has been verified as working */
   httpGatewayVerified = false;
   /** HTTP Gateway info */

--- a/tests/integration/http-gateway.spec.ts
+++ b/tests/integration/http-gateway.spec.ts
@@ -53,7 +53,7 @@ describe('HTTP Gateway', () => {
       await startTransfer(transferSpec, {});
 
       const call = lastFetchCall();
-      expect(call.url).toBe(`${GATEWAY_URL}/presign`);
+      expect(call.url).toBe(`${GATEWAY_URL}/v3/presign`);
       expect(call.method).toBe('POST');
       expect(call.headers['Content-Type']).toBe('application/json');
       expect(call.body).toEqual({

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -124,6 +124,7 @@ export function setupSdk(options: SetupOptions) {
       download_endpoint: [],
       endpoints: [],
     };
+    asperaSdk.globals.httpGatewayRoutePrefix = '/v3';
     // Create iframe container for presign flow
     if (typeof document !== 'undefined') {
       let container = document.getElementById('http-gateway-iframe-container') as HTMLDivElement;
@@ -158,6 +159,7 @@ export function resetSdk() {
   // Reset state
   asperaSdk.globals.httpGatewayVerified = false;
   asperaSdk.globals.httpGatewayUrl = undefined;
+  asperaSdk.globals.httpGatewayRoutePrefix = '';
   asperaSdk.globals.httpGatewayInfo = undefined;
   asperaSdk.globals.httpGatewayIframeContainer = undefined;
   asperaSdk.httpGatewaySelectedFiles.clear();


### PR DESCRIPTION
## Testing
HTTP Gateway URL:
1. `http://127.0.0.1:3000` -> found v3
2. `https://gateway.example.com/aspera/http-gwy` -> found v3
3. `http://127.0.0.1:8080/aspera/http-gwy` -> found v3

Could upload and download with all 3.