### PR TITLE
fix: missing Connect version field from InitOptions

### DIFF
--- a/src/app/core.ts
+++ b/src/app/core.ts
@@ -110,8 +110,7 @@ export const init = (options?: InitOptions): Promise<any> => {
 
   asperaSdk.globals.appId = appId;
 
-  // For now ignore multi user support in Safari
-  if (options?.supportMultipleUsers && !isSafari()) {
+  if (options?.supportMultipleUsers) {
     asperaSdk.globals.supportMultipleUsers = true;
     asperaSdk.globals.sessionId = randomUUID();
   }
@@ -132,6 +131,7 @@ export const init = (options?: InitOptions): Promise<any> => {
       sdkLocation: options.connectSettings.sdkLocation,
       correlationId: options.connectSettings.correlationId,
       style: 'carbon',
+      version: options.connectSettings.version,
     });
 
     asperaSdk.globals.connectAW4 = {

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -834,6 +834,8 @@ export interface InitOptions {
     correlationId?: string;
     /** Indicate if default Connect installer window should not be shown */
     hideIncludedInstaller?: boolean;
+    /** Connect installer version to offer for downloads. This option is ignored if `sdkLocation` is specified. Only supports versions `4.x.x`. */
+    version?: string;
   }
 }
 


### PR DESCRIPTION
Closes #210 

Can now set the `version` option when constructing the internal `ConnectInstaller` instance.