### PR TITLE
test: file checksum example

### DIFF
--- a/examples/file-checksum.ts
+++ b/examples/file-checksum.ts
@@ -15,7 +15,7 @@ declare global {
 window.checksumData = null;
 window.selectedFilePath = null;
 
-export function selectAndCalculateChecksumAspera() {
+export function selectAndCalculateChecksumAspera(options?: { checksumMethod?: 'md5'|'sha1'|'sha256'|'sha512'; offset?: number; chunkSize?: number }) {
   /**
    * This demonstrates a typical web application flow:
    * 1. Use showSelectFileDialog to let the user select a file
@@ -39,8 +39,13 @@ export function selectAndCalculateChecksumAspera() {
     const filePath = selectedFile.name;
     window.selectedFilePath = filePath;
 
-    // Step 2: Read the selected file as an array buffer
-    return getChecksum({path: filePath});
+    // Step 2: Calculate the checksum for the selected file
+    return getChecksum({
+      path: filePath,
+      checksumMethod: options?.checksumMethod,
+      offset: options?.offset,
+      chunkSize: options?.chunkSize,
+    });
   }).then(response => {
     if (!response) {
       return; // User canceled or no file selected

--- a/examples/src/Views/FileChecksum.tsx
+++ b/examples/src/Views/FileChecksum.tsx
@@ -1,13 +1,18 @@
 import './Views.scss';
-import { Button, CodeSnippet } from '@carbon/react';
+import { Button, CodeSnippet, Dropdown, TextInput } from '@carbon/react';
 import { useEffect, useState } from 'react';
 import hljs from 'highlight.js';
 
+const checksumMethods = ['md5', 'sha1', 'sha256', 'sha512'] as const;
+
 export default function FileChecksum() {
   const [selectedFile, setSelectedFile] = useState<string>('');
-  const [checksumData, setFileChecksum] = useState<{data: string; type: string} | null>(null);
+  const [checksumData, setFileChecksum] = useState<{checksum: string; checksumMethod: string} | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [checksumMethod, setChecksumMethod] = useState<string>('md5');
+  const [offset, setOffset] = useState<string>('0');
+  const [chunkSize, setChunkSize] = useState<string>('0');
 
   useEffect(() => {
     document.querySelector('.cds--snippet-container > pre > code')?.classList.add('language-javascript');
@@ -21,7 +26,11 @@ export default function FileChecksum() {
     setSelectedFile('');
 
     try {
-      await window.selectAndCalculateChecksumAspera();
+      await window.selectAndCalculateChecksumAspera({
+        checksumMethod,
+        offset: Number(offset) || 0,
+        chunkSize: Number(chunkSize) || 0,
+      });
     } catch (err) {
       console.error('Failed to select and get file checksum', err);
     } finally {
@@ -51,6 +60,16 @@ export default function FileChecksum() {
       <CodeSnippet type="multi" feedback="Copied to clipboard" maxCollapsedNumberOfRows={25}>{window.selectAndCalculateChecksumAspera.toString()}</CodeSnippet>
       <h2>Try it out</h2>
       <div className="input-group">
+        <Dropdown
+          id="checksum-method"
+          titleText="Checksum Method"
+          label="Select method"
+          items={[...checksumMethods]}
+          selectedItem={checksumMethod}
+          onChange={({ selectedItem }) => setChecksumMethod(selectedItem)}
+        />
+        <TextInput id="checksum-offset" className="code-input" value={offset} onChange={e => setOffset(e.target.value)} labelText="Offset" helperText="Byte offset to start reading from" />
+        <TextInput id="checksum-chunk-size" className="code-input" value={chunkSize} onChange={e => setChunkSize(e.target.value)} labelText="Chunk Size" helperText="Number of bytes to read. 0 reads the entire file" />
         <Button
           onClick={handleSelectAndCalculateChecksum}
           disabled={loading}
@@ -67,12 +86,13 @@ export default function FileChecksum() {
         )}
         {checksumData && (
           <div>
-            <p>{checksumData.data}</p>
+            <p><strong>Method:</strong> {checksumData.checksumMethod}</p>
+            <p><strong>Checksum:</strong> {checksumData.checksum}</p>
           </div>
         )}
         {selectedFile && (
           <div>
-            <p>{selectedFile}</p>
+            <p><strong>File:</strong> {selectedFile}</p>
           </div>
         )}
       </div>

--- a/examples/src/Views/Views.scss
+++ b/examples/src/Views/Views.scss
@@ -40,6 +40,11 @@
     max-width: 48rem;
   }
 
+  .cds--dropdown {
+    max-width: 20rem;
+    margin-bottom: 2rem;
+  }
+
   pre, code {
     font-family: 'IBM Plex Mono', monospace;
   }


### PR DESCRIPTION
### Add checksum method selection and file reading options to File Checksum tab

Added new UI controls to the File Checksum example tab:
- **Checksum Method dropdown**: Select from MD5, SHA1, SHA256, or SHA512 algorithms
- **Offset input**: Specify byte offset to start reading from
- **Chunk Size input**: Define number of bytes to read (0 reads entire file)

These options allow users to test different checksum algorithms and partial file reading scenarios.