### PR TITLE
feat: authenticate()

### DIFF
--- a/examples/index.ts
+++ b/examples/index.ts
@@ -10,7 +10,7 @@ import { testAspera } from './test-connection';
 import { selectItemsAspera } from './select-items';
 import { selectAndPreviewImageAspera } from './image-preview';
 import { selectAndCalculateChecksumAspera } from './file-checksum';
-import { startTransferAspera } from './start-transfer';
+import { startTransferAspera, authenticateAspera } from './start-transfer';
 import { setupDropAspera } from './drag-drop';
 import {
   monitorTransfersAspera,
@@ -37,6 +37,7 @@ declare global {
     selectAndPreviewImageAspera: typeof selectAndPreviewImageAspera;
     selectAndCalculateChecksumAspera: typeof selectAndCalculateChecksumAspera;
     startTransferAspera: typeof startTransferAspera;
+    authenticateAspera: typeof authenticateAspera;
     setupDropAspera: typeof setupDropAspera;
     monitorTransfersAspera: typeof monitorTransfersAspera;
     removeTransferAspera: typeof removeTransferAspera;
@@ -63,6 +64,7 @@ window.selectItemsAspera = selectItemsAspera;
 window.selectAndPreviewImageAspera = selectAndPreviewImageAspera;
 window.selectAndCalculateChecksumAspera = selectAndCalculateChecksumAspera;
 window.startTransferAspera = startTransferAspera;
+window.authenticateAspera = authenticateAspera;
 window.setupDropAspera = setupDropAspera;
 window.monitorTransfersAspera = monitorTransfersAspera;
 window.removeTransferAspera = removeTransferAspera;
@@ -88,6 +90,7 @@ export {
   selectAndPreviewImageAspera,
   selectAndCalculateChecksumAspera,
   startTransferAspera,
+  authenticateAspera,
   setupDropAspera,
   monitorTransfersAspera,
   removeTransferAspera,

--- a/examples/src/Views/StartTransfer.tsx
+++ b/examples/src/Views/StartTransfer.tsx
@@ -20,6 +20,15 @@ export default function StartTransfer() {
     }
   }
 
+  const authenticateTransfer = (): void => {
+    try {
+      window.authenticateAspera(JSON.parse(transferSpec));
+    } catch (error) {
+      console.error('Authenticate failed to parse transferSpec', {error, transferSpec});
+      alert('Unable to parse transfer spec for authentication');
+    }
+  }
+
   const setTransferSpecItem = (value: string): void => {
     localStorage.setItem('ASPERA-SDK-TRANSFER-SPEC', value);
     setTransferSpec(value);
@@ -28,10 +37,13 @@ export default function StartTransfer() {
   return (
     <div className="example-pages">
       <h2>Code example</h2>
-      <CodeSnippet type="multi" feedback="Copied to clipboard" maxCollapsedNumberOfRows={25}>{window.startTransferAspera.toString()}</CodeSnippet>
+      <CodeSnippet type="multi" feedback="Copied to clipboard" maxCollapsedNumberOfRows={25}>{[window.startTransferAspera.toString(), window.authenticateAspera.toString()].join('\n\n')}</CodeSnippet>
       <h2>Try it out</h2>
       <TextArea className="code-input" value={transferSpec} onChange={value => setTransferSpecItem(value.target.value)} labelText="Transfer spec" helperText="Paste a transfer spec to test a transfer. For uploads be sure to select the items first on the 'Select items' page." />
-      <Button onClick={startTransfer}>Start transfer</Button>
+      <div style={{display: 'flex', gap: '1rem'}}>
+        <Button onClick={startTransfer}>Start transfer</Button>
+        <Button onClick={authenticateTransfer} kind="secondary">Authenticate</Button>
+      </div>
     </div>
   );
 };

--- a/examples/start-transfer.ts
+++ b/examples/start-transfer.ts
@@ -3,7 +3,7 @@
  * This example shows how to initiate file transfers.
  */
 
-import { startTransfer } from '@ibm-aspera/sdk';
+import { startTransfer, authenticate } from '@ibm-aspera/sdk';
 
 export function startTransferAspera(transferSpec: any) {
   /** The AsperaSpec defines rules on how the client app should work with transfers */
@@ -16,5 +16,16 @@ export function startTransferAspera(transferSpec: any) {
     // Transfer not accepted by the Aspera app
     console.error('Start transfer failed', error);
     alert(`Start transfer failed\n\n${JSON.stringify(error, undefined, 2)}`);
+  });
+}
+
+export function authenticateAspera(transferSpec: any) {
+  /** Authenticate a transfer specification against the remote server. */
+  authenticate(transferSpec).then(response => {
+    console.info('Authenticate response', response);
+    alert(`Authentication successful:\n\n${JSON.stringify(response, undefined, 2)}`);
+  }).catch(error => {
+    console.error('Authenticate failed', error);
+    alert(`Authentication failed\n\n${JSON.stringify(error, undefined, 2)}`);
   });
 }

--- a/src/app/core.ts
+++ b/src/app/core.ts
@@ -196,6 +196,40 @@ export const init = (options?: InitOptions): Promise<any> => {
 };
 
 /**
+ * Authenticates a transfer specification against the remote server.
+ *
+ * Supported for Connect and IBM Aspera for desktop. Not supported for HTTP Gateway.
+ *
+ * @param transferSpec the transfer specification to authenticate.
+ *
+ * @returns a promise that resolves if authentication is successful and rejects otherwise.
+ */
+export const authenticate = (transferSpec: TransferSpec): Promise<any> => {
+  if (asperaSdk.useHttpGateway) {
+    return throwError(messages.authenticateNotSupported);
+  }
+
+  if (asperaSdk.useConnect) {
+    return asperaSdk.globals.connect.authenticate(transferSpec as unknown as ConnectTypes.TransferSpec);
+  }
+
+  if (!asperaSdk.isReady) {
+    return throwError(messages.serverNotVerified);
+  }
+
+  const promiseInfo = generatePromiseObjects();
+
+  client.request('authenticate', {transfer_spec: transferSpec})
+    .then((data: any) => promiseInfo.resolver(data))
+    .catch(error => {
+      errorLog(messages.authenticateFailed, error);
+      promiseInfo.rejecter(generateErrorBody(messages.authenticateFailed, error));
+    });
+
+  return promiseInfo.promise;
+};
+
+/**
  * Start a transfer
  *
  * @param transferSpec standard transferSpec for transfer
@@ -1221,7 +1255,7 @@ const supportsMethod = (method: string): boolean => {
   // We currently do not support calculating file checksums when using HTTP Gateway. In theory it should be possible
   // to calculate this directly in the browser similar to how `readAsArrayBuffer()` is implemented.
   // HTTP Gateway also does not support showing native transfer client UI (about, preferences, etc.).
-  if (asperaSdk.useHttpGateway && (method === 'get_checksum' || method === 'show_about' || method === 'open_preferences' || method === 'show_transfer_manager' || method === 'show_transfer_monitor' || method === 'read_directory')) {
+  if (asperaSdk.useHttpGateway && (method === 'get_checksum' || method === 'show_about' || method === 'open_preferences' || method === 'show_transfer_manager' || method === 'show_transfer_monitor' || method === 'authenticate' || method === 'read_directory')) {
     return false;
   }
 
@@ -1266,6 +1300,7 @@ export const getCapabilities = (): SdkCapabilities => {
     showPreferences: supportsMethod('open_preferences'),
     showTransferManager: supportsMethod('show_transfer_manager'),
     showTransferMonitor: supportsMethod('show_transfer_monitor'),
+    authenticate: supportsMethod('authenticate'),
     readDirectory: supportsMethod('read_directory'),
   };
 };

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -49,4 +49,6 @@ export const messages = {
   openPreferencesPageNotSupported: 'Open preferences page is not supported for current transfer client',
   showTransferMonitorFailed: 'Unable to show transfer monitor',
   showTransferMonitorNotSupported: 'Show transfer monitor is not supported for current transfer client',
+  authenticateFailed: 'Unable to authenticate',
+  authenticateNotSupported: 'Authenticate is not supported for current transfer client',
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import {AsperaSdk} from './models/aspera-sdk.model';
-import {createDropzone, deregisterActivityCallback, deregisterStatusCallback, getAllTransfers, getCapabilities, getChecksum, getFilesList, getInfo, getTransfer, hasCapability, init, initDragDrop, modifyTransfer, showPreferencesPage, readAsArrayBuffer, readChunkAsArrayBuffer, readDirectory, registerActivityCallback, registerStatusCallback, removeDropzone, removeTransfer, resumeTransfer, setBranding, showAbout, showDirectory, showPreferences, showSelectFileDialog, showSelectFolderDialog, showTransferManager, showTransferMonitor, startTransfer, stopTransfer, testConnection,} from './app/core';
+import {authenticate, createDropzone, deregisterActivityCallback, deregisterStatusCallback, getAllTransfers, getCapabilities, getChecksum, getFilesList, getInfo, getTransfer, hasCapability, init, initDragDrop, modifyTransfer, showPreferencesPage, readAsArrayBuffer, readChunkAsArrayBuffer, readDirectory, registerActivityCallback, registerStatusCallback, removeDropzone, removeTransfer, resumeTransfer, setBranding, showAbout, showDirectory, showPreferences, showSelectFileDialog, showSelectFolderDialog, showTransferManager, showTransferMonitor, startTransfer, stopTransfer, testConnection,} from './app/core';
 import {getInstallerInfo} from './app/installer';
 import {getInstallerUrls, isSafari} from './helpers/helpers';
 import * as httpGatewayCalls from './http-gateway';
@@ -7,6 +7,7 @@ import * as httpGatewayCalls from './http-gateway';
 export const asperaSdk: AsperaSdk = new AsperaSdk();
 
 asperaSdk.init = init;
+asperaSdk.authenticate = authenticate;
 asperaSdk.testConnection = testConnection;
 asperaSdk.startTransfer = startTransfer;
 asperaSdk.registerActivityCallback = registerActivityCallback;
@@ -54,6 +55,7 @@ if (typeof (<any>window) === 'object') {
 export {
   isSafari,
   init,
+  authenticate,
   testConnection,
   startTransfer,
   launch,

--- a/src/models/aspera-sdk.model.ts
+++ b/src/models/aspera-sdk.model.ts
@@ -401,6 +401,8 @@ export class AsperaSdk {
   showPreferencesPage: (options: ShowPreferencesPageOptions) => Promise<any>;
   /** Function to show the transfer rate monitor for a specific transfer */
   showTransferMonitor: (transferId: string) => Promise<any>;
+  /** Function to authenticate a transfer specification against the remote server */
+  authenticate: (transferSpec: TransferSpec) => Promise<any>;
   /** Function to modify a running transfer */
   modifyTransfer: (transferId: string, options: ModifyTransferOptions) => Promise<AsperaSdkTransfer>;
   /** Function to set custom branding for IBM Aspera */

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -1006,6 +1006,13 @@ export interface SdkCapabilities {
    */
   showTransferMonitor: boolean,
   /**
+   * Whether the transfer client supports authenticating a transfer specification.
+   *
+   * This is supported when using Connect or IBM Aspera for desktop with the required RPC methods,
+   * but not HTTP Gateway.
+   */
+  authenticate: boolean,
+  /**
    * Whether the SDK can read directory contents.
    *
    * This is supported when using IBM Aspera for desktop with the required RPC methods,

--- a/tests/integration/connect.spec.ts
+++ b/tests/integration/connect.spec.ts
@@ -17,6 +17,7 @@ import {
   readDirectory,
   showTransferManager,
   showTransferMonitor,
+  authenticate,
   openPreferencesPage,
   hasCapability,
 } from '../../src/index';
@@ -252,6 +253,16 @@ describe('Connect SDK', () => {
     });
   });
 
+  describe('authenticate', () => {
+    it('should call authenticate on Connect SDK with transfer spec', async () => {
+      const transferSpec = {remote_host: 'files.example.com', direction: 'send' as const, paths: [{source: '/file.txt'}]};
+      await authenticate(transferSpec);
+
+      const mock = getConnectMock();
+      expect(mock.authenticate).toHaveBeenCalledWith(transferSpec);
+    });
+  });
+
   describe('openPreferencesPage', () => {
     it('should call showPreferencesPage on Connect SDK with original page value', async () => {
       await openPreferencesPage({page: 'general'});
@@ -290,6 +301,7 @@ describe('Connect SDK', () => {
       expect(hasCapability('showPreferences')).toBe(true);
       expect(hasCapability('showTransferManager')).toBe(true);
       expect(hasCapability('showTransferMonitor')).toBe(true);
+      expect(hasCapability('authenticate')).toBe(true);
       expect(hasCapability('imagePreview')).toBe(true);
       expect(hasCapability('fileChecksum')).toBe(true);
     });

--- a/tests/integration/desktop-app.spec.ts
+++ b/tests/integration/desktop-app.spec.ts
@@ -17,6 +17,7 @@ import {
   readDirectory,
   showTransferManager,
   showTransferMonitor,
+  authenticate,
   openPreferencesPage,
   hasCapability,
 } from '../../src/index';
@@ -150,6 +151,17 @@ describe('Desktop App', () => {
       const call = lastFetchCall();
       expect(call.body.method).toBe('show_transfer_monitor');
       expect(call.body.params).toEqual({transfer_id: 'transfer-uuid-123'});
+    });
+  });
+
+  describe('authenticate', () => {
+    it('should call authenticate RPC with transfer_spec', async () => {
+      const transferSpec = {remote_host: 'files.example.com', direction: 'send' as const, paths: [{source: '/file.txt'}]};
+      await authenticate(transferSpec);
+
+      const call = lastFetchCall();
+      expect(call.body.method).toBe('authenticate');
+      expect(call.body.params).toEqual({transfer_spec: transferSpec});
     });
   });
 
@@ -355,12 +367,13 @@ describe('Desktop App', () => {
 
   describe('hasCapability', () => {
     it('should return true for capabilities whose RPC methods are discovered', () => {
-      asperaSdk.globals.rpcMethods = ['show_about', 'open_preferences', 'show_transfer_manager', 'show_transfer_monitor', 'read_as_array_buffer', 'read_chunk_as_array_buffer', 'get_checksum', 'read_directory'];
+      asperaSdk.globals.rpcMethods = ['show_about', 'open_preferences', 'show_transfer_manager', 'show_transfer_monitor', 'authenticate', 'read_as_array_buffer', 'read_chunk_as_array_buffer', 'get_checksum', 'read_directory'];
 
       expect(hasCapability('showAbout')).toBe(true);
       expect(hasCapability('showPreferences')).toBe(true);
       expect(hasCapability('showTransferManager')).toBe(true);
       expect(hasCapability('showTransferMonitor')).toBe(true);
+      expect(hasCapability('authenticate')).toBe(true);
       expect(hasCapability('imagePreview')).toBe(true);
       expect(hasCapability('fileChecksum')).toBe(true);
       expect(hasCapability('readDirectory')).toBe(true);
@@ -373,6 +386,7 @@ describe('Desktop App', () => {
       expect(hasCapability('showPreferences')).toBe(false);
       expect(hasCapability('showTransferManager')).toBe(false);
       expect(hasCapability('showTransferMonitor')).toBe(false);
+      expect(hasCapability('authenticate')).toBe(false);
       expect(hasCapability('imagePreview')).toBe(false);
       expect(hasCapability('fileChecksum')).toBe(false);
       expect(hasCapability('readDirectory')).toBe(false);

--- a/tests/integration/http-gateway.spec.ts
+++ b/tests/integration/http-gateway.spec.ts
@@ -18,6 +18,7 @@ import {
   readDirectory,
   showTransferManager,
   showTransferMonitor,
+  authenticate,
   openPreferencesPage,
   hasCapability,
   asperaSdk,
@@ -351,6 +352,15 @@ describe('HTTP Gateway', () => {
     });
   });
 
+  describe('authenticate', () => {
+    it('should reject - not supported in HTTP Gateway mode', async () => {
+      await expect(authenticate({remote_host: 'files.example.com', direction: 'send', paths: [{source: '/file.txt'}]})).rejects.toEqual({
+        error: true,
+        message: 'Authenticate is not supported for current transfer client',
+      });
+    });
+  });
+
   describe('openPreferencesPage', () => {
     it('should reject - not supported in HTTP Gateway mode', async () => {
       await expect(openPreferencesPage({page: 'general'})).rejects.toEqual({
@@ -366,6 +376,7 @@ describe('HTTP Gateway', () => {
       expect(hasCapability('showPreferences')).toBe(false);
       expect(hasCapability('showTransferManager')).toBe(false);
       expect(hasCapability('showTransferMonitor')).toBe(false);
+      expect(hasCapability('authenticate')).toBe(false);
       expect(hasCapability('fileChecksum')).toBe(false);
       expect(hasCapability('readDirectory')).toBe(false);
     });

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -235,6 +235,10 @@ function createConnectMock(): any {
       capture('showTransferMonitor')(...args);
       return Promise.resolve({});
     }),
+    authenticate: jest.fn().mockImplementation((...args) => {
+      capture('authenticate')(...args);
+      return Promise.resolve({});
+    }),
     getTransfer: jest.fn().mockImplementation((...args) => {
       capture('getTransfer')(...args);
       return Promise.resolve({transfer_info: {uuid: args[0]}});


### PR DESCRIPTION
```typescript
if (!asperaSdk.hasCapability('authenticate')) {
  throw new Error('authenticate not supported');
}

try {
  const result = await asperaSdk.authenticate(transferSpec);
  console.log('Authenticated:', result);
} catch (err) {
  console.error('Authentication failed:', err);
}
```