### PR TITLE
fix: ws race

### DIFF
--- a/src/helpers/ws.ts
+++ b/src/helpers/ws.ts
@@ -129,6 +129,8 @@ export class WebsocketService {
   }
 
   private connect() {
+    this.detachSocket();
+
     this.getWebSocketConnection(asperaSdk.globals.rpcPort)
       .then((webSocket) => {
         this.globalSocket = webSocket;
@@ -143,7 +145,21 @@ export class WebsocketService {
       });
   }
 
+  /**
+   * Detach event handlers from the current socket so it cannot fire
+   * stale CLOSED/RECONNECT events after being replaced.
+   */
+  private detachSocket(): void {
+    if (this.globalSocket) {
+      this.globalSocket.onopen = null;
+      this.globalSocket.onclose = null;
+      this.globalSocket.onerror = null;
+      this.globalSocket.onmessage = null;
+    }
+  }
+
   private reconnect() {
+    this.detachSocket();
     if (this.globalSocket) {
       this.globalSocket.close();
     }


### PR DESCRIPTION
This should fix a weird race condition I only saw once, but was unable to reproduce. Observed that the SDK was oscillating between DEGRADED <--> RUNNING even with the desktop app running. My theory is that it was because we never cleaned up the old websocket callbacks when creating a new one. So an old callback would fire that the websocket was closed, which would go back to DEGRADED. Then the new callback would fire that it was opened, going back to RUNNING.