### PR TITLE
fix: sdk ready when status goes to running

### DIFF
--- a/src/models/aspera-sdk.model.ts
+++ b/src/models/aspera-sdk.model.ts
@@ -168,13 +168,28 @@ export class ActivityTracking {
    * @param webSocketEvent the event type.
    */
   handleWebSocketEvents(webSocketEvent: WebsocketEvent): void {
-    let current_status = statusService.getStatus();
+    const current_status = statusService.getStatus();
 
     if (webSocketEvent === 'CLOSED') {
       statusService.setStatus('DISCONNECTED');
-    } else if (webSocketEvent === 'RECONNECT' && (current_status === 'DISCONNECTED' || current_status === 'DEGRADED')) {
-      // We make sure we only emit RUNNING if we were previously DISCONNECTED|DEGRADED. The authoritative RUNNING
-      // status on initialization is handled by the status service.
+      return;
+    }
+
+    if (webSocketEvent !== 'RECONNECT') {
+      return;
+    }
+
+    // Only treat RECONNECT as a transition to RUNNING when we have prior verification of
+    // IBM Aspera for desktop. For example, if IBM Aspera for desktop was RUNNING and verified,
+    // and then the user quits and restarts the application.
+    //
+    // TODO: This potentially leads to a data race if the application was quit/restarted because it was being
+    // upgraded. The new application may have newer RPC methods, but transitioning to RUNNING here could
+    // potentially lead to an application seeing stale RPC methods if they call `hasCapability()`, for example,
+    // in the status event listener.
+    const wasPreviouslyVerified = asperaSdk.globals.rpcMethods.length > 0;
+
+    if (current_status === 'DISCONNECTED' || (current_status === 'DEGRADED' && wasPreviouslyVerified)) {
       statusService.setStatus('RUNNING');
     }
   }

--- a/src/models/aspera-sdk.model.ts
+++ b/src/models/aspera-sdk.model.ts
@@ -168,9 +168,13 @@ export class ActivityTracking {
    * @param webSocketEvent the event type.
    */
   handleWebSocketEvents(webSocketEvent: WebsocketEvent): void {
+    let current_status = statusService.getStatus();
+
     if (webSocketEvent === 'CLOSED') {
       statusService.setStatus('DISCONNECTED');
-    } else if (webSocketEvent === 'RECONNECT') {
+    } else if (webSocketEvent === 'RECONNECT' && (current_status === 'DISCONNECTED' || current_status === 'DEGRADED')) {
+      // We make sure we only emit RUNNING if we were previously DISCONNECTED|DEGRADED. The authoritative RUNNING
+      // status on initialization is handled by the status service.
       statusService.setStatus('RUNNING');
     }
   }


### PR DESCRIPTION
#242 

Fixes the issue where an event listener set via `registerStatusCallback()` could not immediately call an API when the status went to `RUNNING`.

Tested on Chrome and Safari and now see that API calls in a `RUNNING` handler now go through successfully including any calls to `hasCapability()`.