### PR TITLE
fix: return connect version in getInfo response

### DIFF
--- a/examples/src/Demo/Demo.scss
+++ b/examples/src/Demo/Demo.scss
@@ -116,6 +116,18 @@
     }
   }
 
+  &__client {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  &__version {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.75rem;
+    color: var(--cds-text-secondary);
+  }
+
   &__grid {
     display: flex;
     flex-wrap: wrap;

--- a/examples/src/Demo/Demo.tsx
+++ b/examples/src/Demo/Demo.tsx
@@ -14,6 +14,7 @@ import {
   showTransferManager,
   createDropzone,
   getCapabilities,
+  getInfo,
   getInstallerInfo,
   getTransfer,
   hasCapability,
@@ -21,7 +22,7 @@ import {
   removeTransfer,
   currentTransferClient,
 } from '@ibm-aspera/sdk';
-import type { AsperaSdkTransfer, BrowserStyleFile, InstallerInfo, SdkCapabilities, SdkStatus, TransferClient, TransferSpec } from '@ibm-aspera/sdk';
+import type { AsperaSdkInfo, AsperaSdkTransfer, BrowserStyleFile, InstallerInfo, SdkCapabilities, SdkStatus, TransferClient, TransferSpec } from '@ibm-aspera/sdk';
 import {
   Button,
   Dropdown,
@@ -122,6 +123,7 @@ export default function Demo() {
   const [transfers, setTransfers] = useState<Map<string, AsperaSdkTransfer>>(new Map());
   const [transferSpec, setTransferSpec] = useState(() => localStorage.getItem('ASPERA-DEMO-TRANSFER-SPEC') || DEFAULT_TRANSFER_SPEC);
   const [installerEntries, setInstallerEntries] = useState<InstallerInfo[]>([]);
+  const [sdkInfo, setSdkInfo] = useState<AsperaSdkInfo | null>(null);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const [infoTransfer, setInfoTransfer] = useState<AsperaSdkTransfer | null>(null);
   const dropzoneRegistered = useRef(false);
@@ -152,6 +154,13 @@ export default function Demo() {
       console.error('Failed to fetch installer info', err);
     });
   }, [needsInstaller, installerEntries.length]);
+
+  useEffect(() => {
+    if (!showCapabilities || !activeClient) return;
+    getInfo().then((info) => setSdkInfo(info)).catch((err) => {
+      console.error('Failed to fetch SDK info', err);
+    });
+  }, [showCapabilities, activeClient]);
 
   const appendDroppedPaths = (files: BrowserStyleFile[]): void => {
     if (!files.length) return;
@@ -317,6 +326,14 @@ export default function Demo() {
     };
   }, [capabilities]);
 
+  const activeClientVersion = useMemo(() => {
+    if (!sdkInfo || !activeClient) return null;
+    if (activeClient === 'desktop') return sdkInfo.version;
+    if (activeClient === 'http-gateway') return sdkInfo.httpGateway?.info?.version;
+    if (activeClient === 'connect') return sdkInfo.connect?.version;
+    return null;
+  }, [sdkInfo, activeClient]);
+
   return (
     <div className="demo-page">
       <div className="demo-col demo-col--a">
@@ -380,7 +397,12 @@ export default function Demo() {
         <Tile className="demo-section demo-caps">
           <div className="demo-caps__header">
             <h3>Active client</h3>
-            <Tag type="blue" size="md">{transferClientLabel(activeClient)}</Tag>
+            <div className="demo-caps__client">
+              <Tag type="blue" size="md">{transferClientLabel(activeClient)}</Tag>
+              {activeClientVersion && (
+                <span className="demo-caps__version">v{activeClientVersion}</span>
+              )}
+            </div>
           </div>
           <div className="demo-caps__grid">
             {enabledCaps.enabled.map((c) => (

--- a/src/app/core.ts
+++ b/src/app/core.ts
@@ -1395,6 +1395,24 @@ export const removeDropzone = (elementSelector: string): void => {
  * @returns a promise that returns information about the user's IBM Aspera installation.
  */
 export const getInfo = (): Promise<AsperaSdkInfo> => {
+  // Fetch the Connect application version on demand the first time it's requested.
+  // Cached on `asperaSdk.globals.connectVersion` so subsequent calls return immediately.
+  if (asperaSdk.useConnect && !asperaSdk.globals.connectVersion) {
+    const promiseInfo = generatePromiseObjects();
+
+    asperaSdk.globals.connect.version()
+      .then(info => {
+        asperaSdk.globals.connectVersion = info?.version;
+        promiseInfo.resolver(asperaSdk.globals.sdkResponseData);
+      })
+      .catch(() => {
+        // Best-effort — leave connectVersion undefined if Connect's version() rejects.
+        promiseInfo.resolver(asperaSdk.globals.sdkResponseData);
+      });
+
+    return promiseInfo.promise;
+  }
+
   if (asperaSdk.useHttpGateway || asperaSdk.useConnect) {
     return Promise.resolve(asperaSdk.globals.sdkResponseData);
   }
@@ -1403,9 +1421,7 @@ export const getInfo = (): Promise<AsperaSdkInfo> => {
     return throwError(messages.serverNotVerified);
   }
 
-  return new Promise((resolve, _) => {
-    resolve(asperaSdk.globals.sdkResponseData);
-  });
+  return Promise.resolve(asperaSdk.globals.sdkResponseData);
 };
 
 /**

--- a/src/models/aspera-sdk.model.ts
+++ b/src/models/aspera-sdk.model.ts
@@ -53,6 +53,8 @@ export class AsperaSdkGlobals {
   connectInstaller?: ConnectTypes.ConnectInstallerClientType;
   /** Connect status */
   connectStatus: ConnectTypes.ConnectStatusStrings = 'WAITING';
+  /** Connect application version, populated when Connect transitions to RUNNING. */
+  connectVersion?: string;
 
   backupLaunchMethod(url: string): void {
     window.alert(messages.loadingProtocol);
@@ -91,6 +93,7 @@ export class AsperaSdkGlobals {
       connect: {
         active: this.connectStatus === 'RUNNING',
         status: this.connectStatus,
+        version: this.connectVersion,
       },
     };
   }
@@ -113,6 +116,8 @@ export type AsperaSdkInfo = AsperaSdkClientInfo&{
   connect: {
     active: boolean;
     status: ConnectTypes.ConnectStatusStrings;
+    /** Connect application version, available once Connect has reached the RUNNING status. */
+    version?: string;
   }
 }
 


### PR DESCRIPTION
#205 

```javascript
console.info(await asperaSdk.getInfo());

{
    "verified": false,
    "httpGateway": {
        "verified": true,
        "url": "http://127.0.0.1:8080/aspera/http-gwy",
        "info": {
            "download_endpoints": [
                "/aspera/http-gwy/v1/download"
            ],
            "endpoints": [
                "/aspera/http-gwy/v1/info",
                "/aspera/http-gwy/v1/upload",
                "/aspera/http-gwy/v2/upload",
                "/aspera/http-gwy/v1/download"
            ],
            "name": "IBM Aspera HTTP Gateway",
            "upload_endpoints": [
                "/aspera/http-gwy/v1/upload",
                "/aspera/http-gwy/v2/upload"
            ],
            "version": "2.3.2"
        }
    },
    "connect": {
        "active": true,
        "status": "RUNNING",
        "version": "4.2.19.956"
    }
}
```

Available at `info.connect.version`.