### PR TITLE
fix: generate title for http gateway transfer

### DIFF
--- a/src/http-gateway/core.ts
+++ b/src/http-gateway/core.ts
@@ -322,6 +322,39 @@ export const httpGatewaySelectFileFolderDialog = (options?: FileDialogOptions, f
 };
 
 /**
+ * Generate a human-readable title for an HTTP Gateway transfer. The desktop and Connect
+ * transfer clients populate `title` themselves; HTTP Gateway transfers are constructed
+ * client-side and need a synthesized title for consumer UIs.
+ *
+ * If the caller already supplied a `title` on the spec, that wins. Otherwise we use the
+ * basename of the first source path, suffixed with `(+N)` when there are additional paths.
+ */
+const getTitle = (transferSpec: TransferSpec): string => {
+  if (transferSpec.title) {
+    return transferSpec.title;
+  }
+
+  const paths = transferSpec.paths;
+  if (!paths || paths.length === 0) {
+    return '';
+  }
+
+  const path = paths[0]?.source;
+
+  if (!path) {
+    return '';
+  }
+
+  const first = path.split('/').filter(Boolean).pop() ?? '';
+
+  if (paths.length === 1) {
+    return first;
+  }
+
+  return `${first} (+${paths.length - 1})`;
+};
+
+/**
  * Get a generic transfer object for HTTP Gateway transfers.
  *
  * @param transferSpec - TransferSpec being provided for the HTTP Gateway transfer
@@ -329,6 +362,8 @@ export const httpGatewaySelectFileFolderDialog = (options?: FileDialogOptions, f
  * @returns a transfer object to track status and send to consumers
  */
 export const getSdkTransfer = (transferSpec: TransferSpec): AsperaSdkTransfer => {
+  const title = getTitle(transferSpec);
+
   return {
     uuid: randomUUID(),
     transfer_spec: transferSpec,
@@ -349,7 +384,7 @@ export const getSdkTransfer = (transferSpec: TransferSpec): AsperaSdkTransfer =>
     calculated_rate_kbps: 0,
     elapsed_usec: 0,
     percentage: 0,
-    title: '',
+    title,
     remaining_usec: 0,
     transfer_client: 'http-gateway',
     httpGatewayTransfer: true,

--- a/tests/integration/http-gateway.spec.ts
+++ b/tests/integration/http-gateway.spec.ts
@@ -110,6 +110,89 @@ describe('HTTP Gateway', () => {
     });
   });
 
+  describe('transfer title', () => {
+    it('should use the basename of a single source path', async () => {
+      const result = await startTransfer(
+        downloadSpec({paths: [{source: '/remote/folder/document.pdf'}]}),
+        {},
+      );
+
+      expect(result.title).toBe('document.pdf');
+    });
+
+    it('should suffix with `(+N)` when there are multiple paths', async () => {
+      const result = await startTransfer(
+        downloadSpec({
+          paths: [
+            {source: '/remote/folder/document.pdf'},
+            {source: '/remote/folder/image.png'},
+            {source: '/remote/folder/data.csv'},
+          ],
+        }),
+        {},
+      );
+
+      expect(result.title).toBe('document.pdf (+2)');
+    });
+
+    it('should respect an explicit title from the transfer spec', async () => {
+      const result = await startTransfer(
+        downloadSpec({
+          title: 'Quarterly report bundle',
+          paths: [{source: '/remote/folder/document.pdf'}],
+        }),
+        {},
+      );
+
+      expect(result.title).toBe('Quarterly report bundle');
+    });
+
+    it('should respect an explicit title even with multiple paths', async () => {
+      const result = await startTransfer(
+        downloadSpec({
+          title: 'My selection',
+          paths: [
+            {source: '/remote/a.txt'},
+            {source: '/remote/b.txt'},
+          ],
+        }),
+        {},
+      );
+
+      expect(result.title).toBe('My selection');
+    });
+
+    it('should strip a trailing slash on a folder path', async () => {
+      const result = await startTransfer(
+        downloadSpec({paths: [{source: '/remote/folder/sub/'}]}),
+        {},
+      );
+
+      expect(result.title).toBe('sub');
+    });
+
+    it('should handle a path with no separators', async () => {
+      const result = await startTransfer(
+        downloadSpec({paths: [{source: 'document.pdf'}]}),
+        {},
+      );
+
+      expect(result.title).toBe('document.pdf');
+    });
+
+    it('should return an empty string when paths is empty', async () => {
+      // The startTransfer flow validates the spec, so use the v3 download path which still
+      // creates the SDK transfer object even if the gateway later rejects. The title should
+      // still be computed from the (empty) paths array.
+      const result = await startTransfer(
+        downloadSpec({paths: []}),
+        {},
+      );
+
+      expect(result.title).toBe('');
+    });
+  });
+
   describe('startTransfer (upload)', () => {
     it('should reject when files not selected by user', async () => {
       await expect(startTransfer(uploadSpec({token: 'upload-token'}), {})).rejects.toEqual({


### PR DESCRIPTION
#257 

Transfers going through HTTP Gateway v3 or newer will now have a title generated based on the paths in the transfer spec, similar to titles generated via native transfer clients.