### PR TITLE
feat: allow updating HTTP Gateway global settings 

### DIFF
--- a/src/app/core.ts
+++ b/src/app/core.ts
@@ -2,7 +2,8 @@ import {messages} from '../constants/messages';
 import {client} from '../helpers/client/client';
 import {errorLog, generateErrorBody, generatePromiseObjects, isValidTransferSpec, randomUUID, throwError, withTimeout} from '../helpers/helpers';
 import {httpDownload, httpUpload, setupHttpGateway} from '../http-gateway';
-import {applyHttpGatewayRuntimeSettings, handleHttpGatewayDrop, httpGatewayReadAsArrayBuffer, httpGatewayReadChunkAsArrayBuffer, httpGatewaySelectFileFolderDialog, httpGetAllTransfers, httpGetTransfer, httpRemoveTransfer, httpStopTransfer, sendTransferUpdate} from '../http-gateway/core';
+import {handleHttpGatewayDrop, httpGatewayReadAsArrayBuffer, httpGatewayReadChunkAsArrayBuffer, httpGatewaySelectFileFolderDialog, httpGetAllTransfers, httpGetTransfer, httpRemoveTransfer, httpStopTransfer, sendTransferUpdate} from '../http-gateway/core';
+import {asperaHttpGateway} from '../http-gateway/v2';
 import {asperaSdk} from '../index';
 import {AsperaSdkInfo, AsperaSdkClientInfo, TransferResponse} from '../models/aspera-sdk.model';
 import {CustomBrandingOptions, DataTransferResponse, DropzoneEventData, DropzoneEventType, DropzoneOptions, AsperaSdkSpec, BrowserStyleFile, AsperaSdkTransfer, FileDialogOptions, FolderDialogOptions, SaveFileDialogOptions, InitOptions, ModifyTransferOptions, Pagination, PaginatedFilesResponse, ResumeTransferOptions, TransferSpec, ReadChunkAsArrayBufferResponse, ReadAsArrayBufferResponse, OpenRpcSpec, SdkCapabilities, SdkStatus, GetChecksumOptions, ChecksumFileResponse, ReadDirectoryOptions, ReadDirectoryResponse, ShowPreferencesPageOptions, PreferencesPage, TestSshPortsOptions, TransferClient} from '../models/models';
@@ -125,6 +126,32 @@ const connectDesktop = (): Promise<void> => {
     .then(() => rpcDiscover())
     .then(() => initDragDrop(true))
     .then((): void => undefined);
+};
+
+/**
+ * Update HTTP Gateway settings.
+ *
+ * Partial updates are supported — fields left undefined keep their current value.
+ *
+ * @param settings the settings to update
+ *
+ * @example
+ * // Before init:
+ * updateHttpGatewaySettings({chunkSize: 5_000_000, concurrentUploads: 4});
+ * initSession({appId: 'my-app', httpGatewaySettings: {url: '...', forceGateway: true}});
+ *
+ * @example
+ * // At runtime:
+ * updateHttpGatewaySettings({chunkSize: 5_000_000});
+ */
+export const updateHttpGatewaySettings = (settings: {chunkSize?: number; concurrentUploads?: number}): void => {
+  if (typeof settings?.chunkSize === 'number') {
+    asperaHttpGateway.overwriteDefaultChunkSize(settings.chunkSize);
+  }
+
+  if (typeof settings?.concurrentUploads === 'number') {
+    asperaHttpGateway.overwriteDefaultConcurrentUploads(settings.concurrentUploads);
+  }
 };
 
 /**
@@ -1704,41 +1731,6 @@ export const getCapabilities = (): SdkCapabilities => {
  */
 export const hasCapability = (capability: keyof SdkCapabilities): boolean => {
   return !!getCapabilities()[capability];
-};
-
-/**
- * Update HTTP Gateway runtime settings. These settings only affect HTTP Gateway v2
- * transfers — v3+ does not chunk uploads or queue them internally, so values set here
- * are stored but have no effect when the active gateway is v3+.
- *
- * Can be called before {@link initSession}; values are applied to v2's internal state
- * as soon as a v2 gateway is detected during init. Can also be called at any point
- * after init to update an already-running v2 gateway.
- *
- * Partial updates are supported — fields left undefined keep their current value.
- * Invalid values (non-positive numbers) are silently ignored.
- *
- * @param settings the settings to update
- *
- * @example
- * // Before init:
- * updateHttpGatewaySettings({chunkSize: 5_000_000, concurrentUploads: 4});
- * initSession({appId: 'my-app', httpGatewaySettings: {url: '...', forceGateway: true}});
- *
- * @example
- * // At runtime:
- * updateHttpGatewaySettings({chunkSize: 5_000_000});
- */
-export const updateHttpGatewaySettings = (settings: {chunkSize?: number; concurrentUploads?: number}): void => {
-  if (typeof settings?.chunkSize === 'number' && settings.chunkSize > 0) {
-    asperaSdk.globals.httpGatewayRuntimeSettings.chunkSize = settings.chunkSize;
-  }
-
-  if (typeof settings?.concurrentUploads === 'number' && settings.concurrentUploads > 0) {
-    asperaSdk.globals.httpGatewayRuntimeSettings.concurrentUploads = settings.concurrentUploads;
-  }
-
-  applyHttpGatewayRuntimeSettings();
 };
 
 export const currentTransferClient = (): TransferClient | undefined => {

--- a/src/app/core.ts
+++ b/src/app/core.ts
@@ -2,7 +2,7 @@ import {messages} from '../constants/messages';
 import {client} from '../helpers/client/client';
 import {errorLog, generateErrorBody, generatePromiseObjects, isValidTransferSpec, randomUUID, throwError, withTimeout} from '../helpers/helpers';
 import {httpDownload, httpUpload, setupHttpGateway} from '../http-gateway';
-import {handleHttpGatewayDrop, httpGatewayReadAsArrayBuffer, httpGatewayReadChunkAsArrayBuffer, httpGatewaySelectFileFolderDialog, httpGetAllTransfers, httpGetTransfer, httpRemoveTransfer, httpStopTransfer, sendTransferUpdate} from '../http-gateway/core';
+import {applyHttpGatewayRuntimeSettings, handleHttpGatewayDrop, httpGatewayReadAsArrayBuffer, httpGatewayReadChunkAsArrayBuffer, httpGatewaySelectFileFolderDialog, httpGetAllTransfers, httpGetTransfer, httpRemoveTransfer, httpStopTransfer, sendTransferUpdate} from '../http-gateway/core';
 import {asperaSdk} from '../index';
 import {AsperaSdkInfo, AsperaSdkClientInfo, TransferResponse} from '../models/aspera-sdk.model';
 import {CustomBrandingOptions, DataTransferResponse, DropzoneEventData, DropzoneEventType, DropzoneOptions, AsperaSdkSpec, BrowserStyleFile, AsperaSdkTransfer, FileDialogOptions, FolderDialogOptions, SaveFileDialogOptions, InitOptions, ModifyTransferOptions, Pagination, PaginatedFilesResponse, ResumeTransferOptions, TransferSpec, ReadChunkAsArrayBufferResponse, ReadAsArrayBufferResponse, OpenRpcSpec, SdkCapabilities, SdkStatus, GetChecksumOptions, ChecksumFileResponse, ReadDirectoryOptions, ReadDirectoryResponse, ShowPreferencesPageOptions, PreferencesPage, TestSshPortsOptions, TransferClient} from '../models/models';
@@ -193,6 +193,10 @@ export const init = (options?: InitOptions): Promise<any> => {
   };
 
   if (options?.httpGatewaySettings?.url && !asperaSdk.globals.httpGatewayVerified) {
+    updateHttpGatewaySettings({
+      chunkSize: options.httpGatewaySettings.chunkSize,
+      concurrentUploads: options.httpGatewaySettings.concurrentUploads,
+    });
     return setupHttpGateway(options.httpGatewaySettings.url).then(() => {
       if (options?.httpGatewaySettings?.forceGateway) {
         return Promise.resolve(asperaSdk.globals.sdkResponseData);
@@ -371,6 +375,10 @@ export const initSession = (options?: InitOptions): void => {
   if (options?.httpGatewaySettings?.url && !asperaSdk.globals.httpGatewayVerified) {
     statusService.setStatus('INITIALIZING');
 
+    updateHttpGatewaySettings({
+      chunkSize: options.httpGatewaySettings.chunkSize,
+      concurrentUploads: options.httpGatewaySettings.concurrentUploads,
+    });
     setupHttpGateway(options.httpGatewaySettings.url).then(() => {
       if (options?.httpGatewaySettings?.forceGateway) {
         statusService.setStatus('RUNNING');
@@ -1696,6 +1704,41 @@ export const getCapabilities = (): SdkCapabilities => {
  */
 export const hasCapability = (capability: keyof SdkCapabilities): boolean => {
   return !!getCapabilities()[capability];
+};
+
+/**
+ * Update HTTP Gateway runtime settings. These settings only affect HTTP Gateway v2
+ * transfers — v3+ does not chunk uploads or queue them internally, so values set here
+ * are stored but have no effect when the active gateway is v3+.
+ *
+ * Can be called before {@link initSession}; values are applied to v2's internal state
+ * as soon as a v2 gateway is detected during init. Can also be called at any point
+ * after init to update an already-running v2 gateway.
+ *
+ * Partial updates are supported — fields left undefined keep their current value.
+ * Invalid values (non-positive numbers) are silently ignored.
+ *
+ * @param settings the settings to update
+ *
+ * @example
+ * // Before init:
+ * updateHttpGatewaySettings({chunkSize: 5_000_000, concurrentUploads: 4});
+ * initSession({appId: 'my-app', httpGatewaySettings: {url: '...', forceGateway: true}});
+ *
+ * @example
+ * // At runtime:
+ * updateHttpGatewaySettings({chunkSize: 5_000_000});
+ */
+export const updateHttpGatewaySettings = (settings: {chunkSize?: number; concurrentUploads?: number}): void => {
+  if (typeof settings?.chunkSize === 'number' && settings.chunkSize > 0) {
+    asperaSdk.globals.httpGatewayRuntimeSettings.chunkSize = settings.chunkSize;
+  }
+
+  if (typeof settings?.concurrentUploads === 'number' && settings.concurrentUploads > 0) {
+    asperaSdk.globals.httpGatewayRuntimeSettings.concurrentUploads = settings.concurrentUploads;
+  }
+
+  applyHttpGatewayRuntimeSettings();
 };
 
 export const currentTransferClient = (): TransferClient | undefined => {

--- a/src/http-gateway/core.ts
+++ b/src/http-gateway/core.ts
@@ -1,7 +1,7 @@
 import {messages} from '../constants/messages';
 import {generateErrorBody, generatePromiseObjects, randomUUID, safeJsonParse, throwError} from '../helpers/helpers';
 import {asperaSdk} from '../index';
-import {asperaHttpGateway, removeTransfer as oldHttpRemoveTransfer, getAllTransfers as oldHttpGetAllTransfers, getTransferById as oldHttpGetTransfer, getFilesForUploadPromise as oldHttpGetFilesForUploadPromise, getFoldersForUploadPromise as oldHttpGetFoldersForUploadPromise, initHttpGateway as oldInitHttpGateway, registerActivityCallback as oldHttpRegisterActivityCallback, cancelTransfer as oldHttpCancelTransfer} from './v2';
+import {removeTransfer as oldHttpRemoveTransfer, getAllTransfers as oldHttpGetAllTransfers, getTransferById as oldHttpGetTransfer, getFilesForUploadPromise as oldHttpGetFilesForUploadPromise, getFoldersForUploadPromise as oldHttpGetFoldersForUploadPromise, initHttpGateway as oldInitHttpGateway, registerActivityCallback as oldHttpRegisterActivityCallback, cancelTransfer as oldHttpCancelTransfer} from './v2';
 import {FileDialogOptions, DataTransferResponse, DropzoneEventData, TransferSpec, AsperaSdkTransfer, ReadAsArrayBufferResponse, ReadChunkAsArrayBufferResponse} from '../models/models';
 import {HttpGatewayInfo} from './models';
 
@@ -56,8 +56,6 @@ export const initHttpGateway = (response: HttpGatewayInfo): Promise<void> => {
         sendTransferUpdate(transfer);
       });
     });
-
-    applyHttpGatewayRuntimeSettings();
 
     return oldInitHttpGateway(asperaSdk.globals.httpGatewayUrl).then(() => {});
   }
@@ -169,23 +167,6 @@ export const httpRemoveTransfer = (id: string): Promise<any> => {
       asperaSdk.httpGatewayTransferStore.delete(id);
       return {removed: true};
     });
-};
-
-/**
- * Push the SDK's current HTTP Gateway runtime settings to v2's internal state.
- *
- * Called automatically from `initHttpGateway` once a v2 gateway is detected, and from
- * `updateHttpGatewaySettings` so runtime changes apply immediately to an already-active
- * v2 gateway. No-ops when the active gateway is v3+ (no chunking or queueing there).
- */
-export const applyHttpGatewayRuntimeSettings = (): void => {
-  if (!asperaSdk.useOldHttpGateway) {
-    return;
-  }
-
-  const {chunkSize, concurrentUploads} = asperaSdk.globals.httpGatewayRuntimeSettings;
-  asperaHttpGateway.overwriteDefaultChunkSize(chunkSize);
-  asperaHttpGateway.overwriteDefaultConcurrentUploads(concurrentUploads);
 };
 
 /**

--- a/src/http-gateway/core.ts
+++ b/src/http-gateway/core.ts
@@ -1,7 +1,7 @@
 import {messages} from '../constants/messages';
 import {generateErrorBody, generatePromiseObjects, randomUUID, safeJsonParse, throwError} from '../helpers/helpers';
 import {asperaSdk} from '../index';
-import {removeTransfer as oldHttpRemoveTransfer, getAllTransfers as oldHttpGetAllTransfers, getTransferById as oldHttpGetTransfer, getFilesForUploadPromise as oldHttpGetFilesForUploadPromise, getFoldersForUploadPromise as oldHttpGetFoldersForUploadPromise, initHttpGateway as oldInitHttpGateway, registerActivityCallback as oldHttpRegisterActivityCallback, cancelTransfer as oldHttpCancelTransfer} from './v2';
+import {asperaHttpGateway, removeTransfer as oldHttpRemoveTransfer, getAllTransfers as oldHttpGetAllTransfers, getTransferById as oldHttpGetTransfer, getFilesForUploadPromise as oldHttpGetFilesForUploadPromise, getFoldersForUploadPromise as oldHttpGetFoldersForUploadPromise, initHttpGateway as oldInitHttpGateway, registerActivityCallback as oldHttpRegisterActivityCallback, cancelTransfer as oldHttpCancelTransfer} from './v2';
 import {FileDialogOptions, DataTransferResponse, DropzoneEventData, TransferSpec, AsperaSdkTransfer, ReadAsArrayBufferResponse, ReadChunkAsArrayBufferResponse} from '../models/models';
 import {HttpGatewayInfo} from './models';
 
@@ -56,6 +56,8 @@ export const initHttpGateway = (response: HttpGatewayInfo): Promise<void> => {
         sendTransferUpdate(transfer);
       });
     });
+
+    applyHttpGatewayRuntimeSettings();
 
     return oldInitHttpGateway(asperaSdk.globals.httpGatewayUrl).then(() => {});
   }
@@ -167,6 +169,23 @@ export const httpRemoveTransfer = (id: string): Promise<any> => {
       asperaSdk.httpGatewayTransferStore.delete(id);
       return {removed: true};
     });
+};
+
+/**
+ * Push the SDK's current HTTP Gateway runtime settings to v2's internal state.
+ *
+ * Called automatically from `initHttpGateway` once a v2 gateway is detected, and from
+ * `updateHttpGatewaySettings` so runtime changes apply immediately to an already-active
+ * v2 gateway. No-ops when the active gateway is v3+ (no chunking or queueing there).
+ */
+export const applyHttpGatewayRuntimeSettings = (): void => {
+  if (!asperaSdk.useOldHttpGateway) {
+    return;
+  }
+
+  const {chunkSize, concurrentUploads} = asperaSdk.globals.httpGatewayRuntimeSettings;
+  asperaHttpGateway.overwriteDefaultChunkSize(chunkSize);
+  asperaHttpGateway.overwriteDefaultConcurrentUploads(concurrentUploads);
 };
 
 /**

--- a/src/http-gateway/v2/models/http-gateway-global.model.ts
+++ b/src/http-gateway/v2/models/http-gateway-global.model.ts
@@ -8,8 +8,8 @@ class HttpGatewayGlobals {
   serverUrl: string;
   /** Server information */
   serverInfo: ServerInfo;
-  /** Chunk size to use for uploads in bytes */
-  chunkSize = 64000;
+  /** Chunk size to use for uploads in bytes. Default: 2 MiB. */
+  chunkSize = 2097152;
   /** Indication that the server has been verified as working */
   serverVerified: boolean;
   /** The ID to use for HTTP Gateway needed DOM items */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import {AsperaSdk} from './models/aspera-sdk.model';
-import {authenticate, createDropzone, deregisterActivityCallback, deregisterStatusCallback, getAllTransfers, getCapabilities, getChecksum, getFilesList, getInfo, getStatus, getTransfer, hasCapability, init, initDragDrop, initSession, modifyTransfer, showPreferencesPage, readAsArrayBuffer, readChunkAsArrayBuffer, readDirectory, registerActivityCallback, registerStatusCallback, removeDropzone, removeTransfer, resumeTransfer, setBranding, showAbout, showDirectory, showPreferences, showSaveFileDialog, showSelectFileDialog, showSelectFolderDialog, showTransferManager, showTransferMonitor, startTransfer, stopTransfer, testConnection, testSshPorts, currentTransferClient} from './app/core';
+import {authenticate, createDropzone, deregisterActivityCallback, deregisterStatusCallback, getAllTransfers, getCapabilities, getChecksum, getFilesList, getInfo, getStatus, getTransfer, hasCapability, init, initDragDrop, initSession, modifyTransfer, showPreferencesPage, readAsArrayBuffer, readChunkAsArrayBuffer, readDirectory, registerActivityCallback, registerStatusCallback, removeDropzone, removeTransfer, resumeTransfer, setBranding, showAbout, showDirectory, showPreferences, showSaveFileDialog, showSelectFileDialog, showSelectFolderDialog, showTransferManager, showTransferMonitor, startTransfer, stopTransfer, testConnection, testSshPorts, updateHttpGatewaySettings, currentTransferClient} from './app/core';
 import {getInstallerInfo} from './app/installer';
 import {getInstallerUrls, isSafari} from './helpers/helpers';
 import * as httpGatewayCalls from './http-gateway';
@@ -48,6 +48,7 @@ asperaSdk.hasCapability = hasCapability;
 asperaSdk.getChecksum = getChecksum;
 asperaSdk.readDirectory = readDirectory;
 asperaSdk.currentTransferClient = currentTransferClient;
+asperaSdk.updateHttpGatewaySettings = updateHttpGatewaySettings;
 asperaSdk.httpGatewayCalls = httpGatewayCalls;
 
 const launch = asperaSdk.globals.launch;
@@ -101,6 +102,7 @@ export {
   getChecksum,
   readDirectory,
   currentTransferClient,
+  updateHttpGatewaySettings,
 };
 
 export type {

--- a/src/models/aspera-sdk.model.ts
+++ b/src/models/aspera-sdk.model.ts
@@ -53,6 +53,16 @@ export class AsperaSdkGlobals {
   connectInstaller?: ConnectTypes.ConnectInstallerClientType;
   /** Connect status */
   connectStatus: ConnectTypes.ConnectStatusStrings = 'WAITING';
+  /**
+   * Runtime HTTP Gateway settings. Only applied to HTTP Gateway v2 transfers — v3+ has no
+   * chunking or queueing, so these are stored but have no effect when a v3+ gateway is active.
+   * Mutated by {@link updateHttpGatewaySettings} and by `initSession` when `httpGatewaySettings`
+   * passes overrides.
+   */
+  httpGatewayRuntimeSettings: { chunkSize: number; concurrentUploads: number } = {
+    chunkSize: 2097152,
+    concurrentUploads: 3,
+  };
   /** Connect application version, populated when Connect transitions to RUNNING. */
   connectVersion?: string;
 
@@ -420,6 +430,8 @@ export class AsperaSdk {
   /** Function to read directory contents and return entries as a flat list */
   readDirectory: (options: ReadDirectoryOptions) => Promise<ReadDirectoryResponse>;
   currentTransferClient: () => TransferClient | undefined;
+  /** Function to update HTTP Gateway runtime settings. Only affects HTTP Gateway v2; v3+ ignores these values. */
+  updateHttpGatewaySettings: (settings: {chunkSize?: number; concurrentUploads?: number}) => void;
   /** Indicate if Safari Extension is enabled. If the extension is disabled during the lifecycle this will not update to disabled. */
   SAFARI_EXTENSION_STATUS: SafariExtensionEvent = 'DISABLED';
   /** Aspera HTTP Gateway calls. This normally is not needed by clients but expose just in case. */

--- a/src/models/aspera-sdk.model.ts
+++ b/src/models/aspera-sdk.model.ts
@@ -420,7 +420,7 @@ export class AsperaSdk {
   /** Function to read directory contents and return entries as a flat list */
   readDirectory: (options: ReadDirectoryOptions) => Promise<ReadDirectoryResponse>;
   currentTransferClient: () => TransferClient | undefined;
-  /** Function to update HTTP Gateway runtime settings. Only affects HTTP Gateway v2; v3+ ignores these values. */
+  /** Function to update HTTP Gateway settings. */
   updateHttpGatewaySettings: (settings: {chunkSize?: number; concurrentUploads?: number}) => void;
   /** Indicate if Safari Extension is enabled. If the extension is disabled during the lifecycle this will not update to disabled. */
   SAFARI_EXTENSION_STATUS: SafariExtensionEvent = 'DISABLED';

--- a/src/models/aspera-sdk.model.ts
+++ b/src/models/aspera-sdk.model.ts
@@ -53,16 +53,6 @@ export class AsperaSdkGlobals {
   connectInstaller?: ConnectTypes.ConnectInstallerClientType;
   /** Connect status */
   connectStatus: ConnectTypes.ConnectStatusStrings = 'WAITING';
-  /**
-   * Runtime HTTP Gateway settings. Only applied to HTTP Gateway v2 transfers — v3+ has no
-   * chunking or queueing, so these are stored but have no effect when a v3+ gateway is active.
-   * Mutated by {@link updateHttpGatewaySettings} and by `initSession` when `httpGatewaySettings`
-   * passes overrides.
-   */
-  httpGatewayRuntimeSettings: { chunkSize: number; concurrentUploads: number } = {
-    chunkSize: 2097152,
-    concurrentUploads: 3,
-  };
   /** Connect application version, populated when Connect transitions to RUNNING. */
   connectVersion?: string;
 

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -985,6 +985,18 @@ export interface InitOptions {
     url: string;
     /** Indicate if HTTP Gateway should be forced. This will not start desktop if httpGatewayUrl is valid. */
     forceGateway: boolean;
+    /**
+     * Chunk size, in bytes, used when uploading via HTTP Gateway v2. v3+ does not chunk
+     * (the browser streams the request), so this value has no effect on v3+ gateways.
+     * Default: 2097152 (2 MiB).
+     */
+    chunkSize?: number;
+    /**
+     * Maximum number of concurrent uploads when using HTTP Gateway v2. v3+ does not queue
+     * uploads internally, so this value has no effect on v3+ gateways.
+     * Default: 3.
+     */
+    concurrentUploads?: number;
   };
   /** Connect Settings */
   connectSettings?: {

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -986,14 +986,17 @@ export interface InitOptions {
     /** Indicate if HTTP Gateway should be forced. This will not start desktop if httpGatewayUrl is valid. */
     forceGateway: boolean;
     /**
-     * Chunk size, in bytes, used when uploading via HTTP Gateway v2. v3+ does not chunk
-     * (the browser streams the request), so this value has no effect on v3+ gateways.
+     * Chunk size, in bytes, used when uploading via HTTP Gateway.
+     *
+     * Note: HTTP Gateway v3 and newer do not chunk (the browser streams the request), so this value has no effect on
+     * newer versions.
+     *
      * Default: 2097152 (2 MiB).
      */
     chunkSize?: number;
     /**
-     * Maximum number of concurrent uploads when using HTTP Gateway v2. v3+ does not queue
-     * uploads internally, so this value has no effect on v3+ gateways.
+     * Maximum number of concurrent uploads when using HTTP Gateway.
+     *
      * Default: 3.
      */
     concurrentUploads?: number;


### PR DESCRIPTION
#265 

If migrating from `@ibm-aspera/http-gateway-sdk-js`:

Previous:
```javascript
import {asperaHttpGateway} from '@ibm-aspera/sdk';
asperaHttpGateway.overwriteDefaultChunkSize(5_000_000);
asperaHttpGateway.overwriteDefaultConcurrentUploads(4);
```

After:
```javascript
import {updateHttpGatewaySettings} from '@ibm-aspera/sdk';
updateHttpGatewaySettings({chunkSize: 5_000_000, concurrentUploads: 4});
```

Note: For now the concurrent uploads setting will only take effect if using HTTP Gateway v2. 

This PR also changes the default chunk size to 2 MiB (64KB was way too low).

