### PR TITLE
feat: allow client to only generate download url

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -7,6 +7,7 @@ export const messages = {
   getInstallerError: 'Unable to get latest installers',
   getAllTransfersFailed: 'Unable to get all transfers',
   getTransferFailed: 'Unable to get transfer',
+  failedToGetDownloadUrl: 'Unable to retrieve HTTP download URL',
   invalidEndpoint: 'The specified endpoint is not a valid URL',
   loadingProtocol: 'Launching IBM Aspera for Desktop',
   modifyTransferFailed: 'Unable to modify transfer',

--- a/src/http-gateway/download.ts
+++ b/src/http-gateway/download.ts
@@ -79,6 +79,17 @@ const httpDownloadPresigned = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
 
     transferObject.httpRequestId = response.headers.get('X-Request-Id');
     transferObject.status = 'running';
+
+    if (asperaSdkSpec?.disableAutoDownload) {
+      // Caller asked for the URL only — surface it on the transfer and skip the iframe.
+      // The transfer entry stays in the store flagged as externally handled; consumer is
+      // responsible for invoking the URL (e.g., window.open) and calling removeTransfer when
+      // they're done with the entry.
+      transferObject.httpDownloadUrl = response.body.signed_url;
+      sendTransferUpdate(transferObject);
+      return transferObject;
+    }
+
     sendTransferUpdate(transferObject);
 
     const iframe = document.createElement('iframe');
@@ -203,6 +214,12 @@ export const httpDownload = (transferSpec: TransferSpec, asperaSdkSpec?: AsperaS
 
   if (asperaSdk.useOldHttpGateway) {
     return oldHttpDownload(transferSpec);
+  }
+
+  // `disableAutoDownload` requires a presigned URL to surface to the caller, so always take
+  // the presigned path regardless of the in-browser-download size threshold.
+  if (asperaSdkSpec?.disableAutoDownload) {
+    return httpDownloadPresigned(transferSpec, asperaSdkSpec);
   }
 
   if (

--- a/src/http-gateway/download.ts
+++ b/src/http-gateway/download.ts
@@ -1,6 +1,6 @@
 import {AsperaSdkSpec, AsperaSdkTransfer, TransferSpec} from '../models/models';
 import {asperaSdk} from '../index';
-import {safeJsonString, throwError} from '../helpers/helpers';
+import {generateErrorBody, safeJsonString, throwError} from '../helpers/helpers';
 import {messages} from '../constants/messages';
 import { base64Encoding, getMessageFromError, getSdkTransfer, sendTransferUpdate } from './core';
 import {download as oldHttpDownload} from './v2';
@@ -30,16 +30,20 @@ const httpDownloadPresigned = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
     sendTransferUpdate(transferObject);
   }
 
-  const triggerFailed = (error: any): void => {
+  // For disableAutoDownload there's no transfer to track, so failures reject once.
+  // For the regular flow, failures resolve with the transfer in a 'failed' state.
+  const handleError = (error: any): Promise<AsperaSdkTransfer> => {
     const errorData = getMessageFromError(error.response || error);
+
+    if (disableAutoDownload) {
+      return Promise.reject(generateErrorBody(messages.failedToGetDownloadUrl, error));
+    }
 
     transferObject.status = 'failed';
     transferObject.error_code = errorData.code;
     transferObject.error_desc = errorData.message;
-
-    if (!disableAutoDownload) {
-      sendTransferUpdate(transferObject);
-    }
+    sendTransferUpdate(transferObject);
+    return Promise.resolve(transferObject);
   };
 
   const url = new URL(asperaSdkSpec?.http_gateway_override_server_url || asperaSdk.globals.httpGatewayUrl);
@@ -81,9 +85,8 @@ const httpDownloadPresigned = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
     });
   }).then(response => {
     if (response.status >= 400) {
-      triggerFailed(response.body);
-
-      return transferObject;
+      // Defer to the single error handler in .catch (avoids double-handling).
+      throw response.body;
     }
 
     transferObject.httpRequestId = response.headers.get('X-Request-Id');
@@ -105,9 +108,7 @@ const httpDownloadPresigned = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
 
     return transferObject;
   }).catch(error => {
-    triggerFailed(error);
-
-    return transferObject;
+    return handleError(error);
   });
 };
 

--- a/src/http-gateway/download.ts
+++ b/src/http-gateway/download.ts
@@ -22,7 +22,13 @@ const httpDownloadPresigned = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
   // create a transfer sdk object
   const transferObject = getSdkTransfer(transferSpec);
   transferObject.httpDownloadExternalHandle = true;
-  sendTransferUpdate(transferObject);
+
+  // When `disableAutoDownload` is set, skip updates and activity callbacks
+  const disableAutoDownload = !!asperaSdkSpec?.disableAutoDownload;
+
+  if (!disableAutoDownload) {
+    sendTransferUpdate(transferObject);
+  }
 
   const triggerFailed = (error: any): void => {
     const errorData = getMessageFromError(error.response || error);
@@ -30,7 +36,10 @@ const httpDownloadPresigned = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
     transferObject.status = 'failed';
     transferObject.error_code = errorData.code;
     transferObject.error_desc = errorData.message;
-    sendTransferUpdate(transferObject);
+
+    if (!disableAutoDownload) {
+      sendTransferUpdate(transferObject);
+    }
   };
 
   const url = new URL(asperaSdkSpec?.http_gateway_override_server_url || asperaSdk.globals.httpGatewayUrl);
@@ -80,13 +89,8 @@ const httpDownloadPresigned = (transferSpec: TransferSpec, asperaSdkSpec?: Asper
     transferObject.httpRequestId = response.headers.get('X-Request-Id');
     transferObject.status = 'running';
 
-    if (asperaSdkSpec?.disableAutoDownload) {
-      // Caller asked for the URL only — surface it on the transfer and skip the iframe.
-      // The transfer entry stays in the store flagged as externally handled; consumer is
-      // responsible for invoking the URL (e.g., window.open) and calling removeTransfer when
-      // they're done with the entry.
+    if (disableAutoDownload) {
       transferObject.httpDownloadUrl = response.body.signed_url;
-      sendTransferUpdate(transferObject);
       return transferObject;
     }
 
@@ -213,6 +217,26 @@ export const httpDownload = (transferSpec: TransferSpec, asperaSdkSpec?: AsperaS
   }
 
   if (asperaSdk.useOldHttpGateway) {
+    if (asperaSdkSpec?.disableAutoDownload) {
+      const transferObject = getSdkTransfer(transferSpec);
+      transferObject.httpDownloadExternalHandle = true;
+
+      // TODO: Pass through all options
+      return oldHttpDownload(transferSpec, {disableAutoDownload: true})
+        .then((response: any) => {
+          transferObject.httpDownloadUrl = response?.url;
+          transferObject.status = 'running';
+          return transferObject;
+        })
+        .catch((error: any) => {
+          const errorData = getMessageFromError(error.response || error);
+          transferObject.status = 'failed';
+          transferObject.error_code = errorData.code;
+          transferObject.error_desc = errorData.message;
+          return transferObject;
+        });
+    }
+
     return oldHttpDownload(transferSpec);
   }
 

--- a/src/http-gateway/download.ts
+++ b/src/http-gateway/download.ts
@@ -227,13 +227,6 @@ export const httpDownload = (transferSpec: TransferSpec, asperaSdkSpec?: AsperaS
           transferObject.httpDownloadUrl = response?.url;
           transferObject.status = 'running';
           return transferObject;
-        })
-        .catch((error: any) => {
-          const errorData = getMessageFromError(error.response || error);
-          transferObject.status = 'failed';
-          transferObject.error_code = errorData.code;
-          transferObject.error_desc = errorData.message;
-          return transferObject;
         });
     }
 

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -353,13 +353,11 @@ export interface AsperaSdkSpec {
   /**
    * For HTTP Gateway downloads only. When `true`, the SDK obtains the presigned download URL
    * but does not automatically initiate the browser download. Instead, the URL is returned on
-   * the resulting transfer as `httpDownloadUrl` so the caller can decide what to do with it —
-   * for example, opening it in a new tab on mobile, where the SDK's default iframe-based
-   * download isn't supported.
+   * the resulting transfer as `httpDownloadUrl` so the caller can decide what to do with it.
    *
    * When set, the SDK always takes the presigned path regardless of the file size threshold.
-   *
-   * Has no effect on uploads, non-gateway transfers, or v3 in-browser downloads.
+   * The returned transfer is not added to the SDK's transfer store and does not fire activity
+   * callbacks — the SDK has no ongoing role after returning the URL.
    */
   disableAutoDownload?: boolean;
 }
@@ -753,7 +751,7 @@ export interface AsperaSdkTransfer {
    * For HTTP Gateway downloads started with `AsperaSdkSpec.disableAutoDownload: true`, this
    * is the presigned download URL returned by the gateway. The SDK does not auto-trigger the
    * download in this mode — the caller is expected to use this URL (e.g., open it in a new
-   * tab) and remove the transfer entry when finished.
+   * tab).
    */
   httpDownloadUrl?: string;
 }

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -350,6 +350,18 @@ export interface AsperaSdkSpec {
    * This is for backwards compatibility with the old SDK.
    */
   http_gateway_v2_transfer_id?: string;
+  /**
+   * For HTTP Gateway downloads only. When `true`, the SDK obtains the presigned download URL
+   * but does not automatically initiate the browser download. Instead, the URL is returned on
+   * the resulting transfer as `httpDownloadUrl` so the caller can decide what to do with it —
+   * for example, opening it in a new tab on mobile, where the SDK's default iframe-based
+   * download isn't supported.
+   *
+   * When set, the SDK always takes the presigned path regardless of the file size threshold.
+   *
+   * Has no effect on uploads, non-gateway transfers, or v3 in-browser downloads.
+   */
+  disableAutoDownload?: boolean;
 }
 
 export interface Path {
@@ -737,6 +749,13 @@ export interface AsperaSdkTransfer {
   httpRequestId?: string;
   /** Indicate if the HTTP Gateway transfer is being done via browser download manager. (No progress updates) */
   httpDownloadExternalHandle?: boolean;
+  /**
+   * For HTTP Gateway downloads started with `AsperaSdkSpec.disableAutoDownload: true`, this
+   * is the presigned download URL returned by the gateway. The SDK does not auto-trigger the
+   * download in this mode — the caller is expected to use this URL (e.g., open it in a new
+   * tab) and remove the transfer entry when finished.
+   */
+  httpDownloadUrl?: string;
 }
 
 export interface InstallerInfo {


### PR DESCRIPTION
#264 

Example usage:
```javascript
import { startTransfer } from '@ibm-aspera/sdk';

// Get the presigned download URL instead of auto-downloading
const transfer = await startTransfer(transferSpec, {
  disableAutoDownload: true,
});

window.open(transfer.httpDownloadUrl, '_blank', 'noopener,noreferrer');
```

Works identically when using both v2 and newer v3 http gateways. Transfer updates will NOT be emitted when starting a download this way as it's simply generating the download URL.