### PR TITLE
fix: check if message is null

### DIFF
--- a/src/models/aspera-sdk.model.ts
+++ b/src/models/aspera-sdk.model.ts
@@ -142,6 +142,10 @@ export class ActivityTracking {
    * @param message the message received
    */
   handleTransferActivity(message: ActivityMessage): void {
+    if (!message) {
+      return;
+    }
+
     const data = message.data && typeof message.data === 'object' && 'transfers' in message.data
       ? message.data
       : {transfers: [message.data]};


### PR DESCRIPTION
Fixes a potential null error case:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'data')
    at <anonymous>:1:9
```